### PR TITLE
PhoneFactory: fix creating a cdma phone type

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -26,6 +26,11 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src/java) \
 
 LOCAL_JAVA_LIBRARIES := voip-common ims-common telephony-ext
 LOCAL_STATIC_JAVA_LIBRARIES := ims-ext-common
+
+ifneq ($(BOARD_RIL_CLASS),)
+LOCAL_SRC_FILES += $(call find-other-java-files,$(BOARD_RIL_CLASS))
+endif
+
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := telephony-common
 

--- a/resources/res/values/config.xml
+++ b/resources/res/values/config.xml
@@ -30,6 +30,5 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <!-- These resources are around just to allow their values to be customized
      for different hardware and product builds.  Do not translate. -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- Configuration for displaying 14 digit IMEI Number -->
-    <bool name="config_enable_display_14digit_imei">false</bool>
+
 </resources>

--- a/src/java/com/android/internal/telephony/BaseCommands.java
+++ b/src/java/com/android/internal/telephony/BaseCommands.java
@@ -852,8 +852,7 @@ public abstract class BaseCommands implements CommandsInterface {
         return mRilVersion;
     }
 
-    public void setUiccSubscription(int slotId, int appIndex, int subId, int subStatus,
-            Message response) {
+    public void setUiccSubscription(int appIndex, boolean activate, Message response) {
     }
 
     public void setDataAllowed(boolean allowed, Message response) {

--- a/src/java/com/android/internal/telephony/CommandsInterface.java
+++ b/src/java/com/android/internal/telephony/CommandsInterface.java
@@ -1924,20 +1924,15 @@ public interface CommandsInterface {
    /**
      * Sets user selected subscription at Modem.
      *
-     * @param slotId
-     *          Slot.
      * @param appIndex
      *          Application index in the card.
-     * @param subId
-     *          Indicates subscription 0 or subscription 1.
-     * @param subStatus
-     *          Activation status, 1 = activate and 0 = deactivate.
+     * @param activate
+     *          Whether to activate or deactivate the subscription
      * @param result
      *          Callback message contains the information of SUCCESS/FAILURE.
      */
     // FIXME Update the doc and consider modifying the request to make more generic.
-    public void setUiccSubscription(int slotId, int appIndex, int subId, int subStatus,
-            Message result);
+    public void setUiccSubscription(int appIndex, boolean activate, Message result);
 
     /**
      * Tells the modem if data is allowed or not.

--- a/src/java/com/android/internal/telephony/PhoneFactory.java
+++ b/src/java/com/android/internal/telephony/PhoneFactory.java
@@ -46,6 +46,7 @@ import com.android.internal.util.IndentingPrintWriter;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.lang.reflect.Constructor;
 import java.util.HashMap;
 
 /**
@@ -156,6 +157,8 @@ public class PhoneFactory {
                 sPhones = new Phone[numPhones];
                 sCommandsInterfaces = new RIL[numPhones];
                 sTelephonyNetworkFactories = new TelephonyNetworkFactory[numPhones];
+                String sRILClassname = SystemProperties.get("ro.telephony.ril_class", "RIL").trim();
+                Rlog.i(LOG_TAG, "RILClassname is " + sRILClassname);
 
                 for (int i = 0; i < numPhones; i++) {
                     // reads the system properties and makes commandsinterface
@@ -163,8 +166,20 @@ public class PhoneFactory {
                     networkModes[i] = preferredNetworkMode;
 
                     Rlog.i(LOG_TAG, "Network Mode set to " + Integer.toString(networkModes[i]));
-                    sCommandsInterfaces[i] = new RIL(context, networkModes[i],
-                            cdmaSubscription, i);
+                    // Use reflection to construct the RIL class (defaults to RIL)
+                    try {
+                        sCommandsInterfaces[i] = instantiateCustomRIL(
+                                sRILClassname, context, networkModes[i], cdmaSubscription, i);
+                    } catch (Exception e) {
+                        // 6 different types of exceptions are thrown here that it's easier to just
+                        // catch Exception as our "error handling" is the same. Yes, we're blocking
+                        // the whole thing and making the radio unusable. That's by design.
+                        // The log message should make it clear why the radio is broken
+                        while (true) {
+                            Rlog.e(LOG_TAG, "Unable to construct custom RIL class", e);
+                            try { Thread.sleep(10000); } catch (InterruptedException ie) {}
+                        }
+                    }
                 }
                 Rlog.i(LOG_TAG, "Creating SubscriptionController");
                 telephonyComponentFactory.initSubscriptionController(
@@ -250,6 +265,16 @@ public class PhoneFactory {
                         context, sPhones, sCommandsInterfaces);
             }
         }
+    }
+
+    private static <T> T instantiateCustomRIL(String sRILClassname, Context context,
+                                        int networkMode, int cdmaSubscription, Integer instanceId)
+                                        throws Exception {
+        Class<?> clazz = Class.forName("com.android.internal.telephony." + sRILClassname);
+        Constructor<?> constructor = clazz.getConstructor(
+                                            Context.class, int.class, int.class, Integer.class);
+        return (T) clazz.cast(constructor.newInstance(
+                                            context, networkMode, cdmaSubscription, instanceId));
     }
 
     public static Phone getDefaultPhone() {

--- a/src/java/com/android/internal/telephony/PhoneFactory.java
+++ b/src/java/com/android/internal/telephony/PhoneFactory.java
@@ -184,7 +184,7 @@ public class PhoneFactory {
                     } else if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {
                         phone = telephonyComponentFactory.makePhone(context,
                                 sCommandsInterfaces[i], sPhoneNotifier, i,
-                                PhoneConstants.PHONE_TYPE_CDMA_LTE,
+                                PhoneConstants.PHONE_TYPE_CDMA,
                                 telephonyComponentFactory);
                     }
                     Rlog.i(LOG_TAG, "Creating Phone with type = " + phoneType + " sub = " + i);

--- a/src/java/com/android/internal/telephony/PhoneFactory.java
+++ b/src/java/com/android/internal/telephony/PhoneFactory.java
@@ -366,6 +366,14 @@ public class PhoneFactory {
        return prompt;
     }
 
+    /* Sets User SMS Prompt property,  enable or not */
+    public static void setSMSPromptEnabled(boolean enabled) {
+        int value = (enabled == false) ? 0 : 1;
+        Settings.Global.putInt(sContext.getContentResolver(),
+                Settings.Global.MULTI_SIM_SMS_PROMPT, value);
+        Rlog.d(LOG_TAG, "setSMSPromptOption to " + enabled);
+    }
+
     /**
      * Makes a {@link ImsPhone} object.
      * @return the {@code ImsPhone} object or null if the exception occured
@@ -504,5 +512,9 @@ public class PhoneFactory {
             pw.flush();
         }
         pw.decreaseIndent();
+    }
+
+    public static SubscriptionInfoUpdater getSubscriptionInfoUpdater() {
+        return sSubInfoRecordUpdater;
     }
 }

--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -241,7 +241,7 @@ class RILRequest {
  *
  * {@hide}
  */
-public final class RIL extends BaseCommands implements CommandsInterface {
+public class RIL extends BaseCommands implements CommandsInterface {
     static final String RILJ_LOG_TAG = "RILJ";
     // Have a separate wakelock instance for Ack
     static final String RILJ_ACK_WAKELOCK_NAME = "RILJ_ACK_WL";
@@ -298,7 +298,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
     // When we are testing emergency calls
     AtomicBoolean mTestingEmergencyCall = new AtomicBoolean(false);
 
-    private Integer mInstanceId;
+    protected Integer mInstanceId;
     private List<String> mOldRilFeatures;
 
     private TelephonyEventLog mEventLog;
@@ -604,10 +604,10 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return messageLength;
     }
 
-    class RILReceiver implements Runnable {
+    protected class RILReceiver implements Runnable {
         byte[] buffer;
 
-        RILReceiver() {
+        protected RILReceiver() {
             buffer = new byte[RIL_MAX_COMMAND_BYTES];
         }
 
@@ -774,7 +774,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
             riljLog("Not starting RILReceiver: wifi-only");
         } else {
             riljLog("Starting RILReceiver" + mInstanceId);
-            mReceiver = new RILReceiver();
+            mReceiver = createRILReceiver();
             mReceiverThread = new Thread(mReceiver, "RILReceiver" + mInstanceId);
             mReceiverThread.start();
 
@@ -794,6 +794,10 @@ public final class RIL extends BaseCommands implements CommandsInterface {
 
         TelephonyDevController tdc = TelephonyDevController.getInstance();
         tdc.registerRIL(this);
+    }
+
+    protected RILReceiver createRILReceiver() {
+        return new RILReceiver();
     }
 
     //***** CommandsInterface implementation
@@ -2410,7 +2414,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private void sendScreenState(boolean on) {
+    protected void sendScreenState(boolean on) {
         RILRequest rr = RILRequest.obtain(RIL_REQUEST_SCREEN_STATE, null);
         rr.mParcel.writeInt(1);
         rr.mParcel.writeInt(on ? 1 : 0);
@@ -2429,7 +2433,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         updateScreenState();
    }
 
-    private RadioState getRadioStateFromInt(int stateInt) {
+    protected RadioState getRadioStateFromInt(int stateInt) {
         RadioState state;
 
         /* RIL_RadioState ril.h */
@@ -2453,7 +2457,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return state;
     }
 
-    private void switchToRadioState(RadioState newState) {
+    protected void switchToRadioState(RadioState newState) {
         setRadioState(newState);
     }
 
@@ -2466,7 +2470,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
      * happen often.
      */
 
-    private void
+    protected void
     acquireWakeLock(RILRequest rr, int wakeLockType) {
         synchronized(rr) {
             if(rr.mWakeLockType != INVALID_WAKELOCK) {
@@ -2550,7 +2554,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private void
+    protected void
     send(RILRequest rr) {
         Message msg;
 
@@ -2565,7 +2569,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         msg.sendToTarget();
     }
 
-    private void
+    protected void
     processResponse (Parcel p) {
         int type;
 
@@ -2606,7 +2610,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
      * @param error is the RIL_Errno sent back
      * @param loggable true means to print all requests in mRequestList
      */
-    private void clearRequestList(int error, boolean loggable) {
+    protected void clearRequestList(int error, boolean loggable) {
         RILRequest rr;
         synchronized (mRequestList) {
             int count = mRequestList.size();
@@ -2630,7 +2634,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private RILRequest findAndRemoveRequestFromList(int serial) {
+    protected RILRequest findAndRemoveRequestFromList(int serial) {
         RILRequest rr = null;
         synchronized (mRequestList) {
             rr = mRequestList.get(serial);
@@ -2642,7 +2646,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return rr;
     }
 
-    private RILRequest
+    protected RILRequest
     processSolicited (Parcel p, int type) {
         int serial, error;
         boolean found = false;
@@ -2924,7 +2928,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return rr;
     }
 
-    private RadioCapability makeStaticRadioCapability() {
+    protected RadioCapability makeStaticRadioCapability() {
         // default to UNKNOWN so we fail fast.
         int raf = RadioAccessFamily.RAF_UNKNOWN;
 
@@ -3024,7 +3028,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return s;
     }
 
-    private void
+    protected void
     processUnsolicited (Parcel p, int type) {
         int response;
         Object ret;
@@ -3560,7 +3564,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
      *
      * @param rilVer is the version of the ril or -1 if disconnected.
      */
-    private void notifyRegistrantsRilConnectionChanged(int rilVer) {
+    protected void notifyRegistrantsRilConnectionChanged(int rilVer) {
         mRilVersion = rilVer;
         if (mRilConnectedRegistrants != null) {
             mRilConnectedRegistrants.notifyRegistrants(
@@ -3568,7 +3572,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private Object
+    protected Object
     responseInts(Parcel p) {
         int numInts;
         int response[];
@@ -3584,7 +3588,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseFailCause(Parcel p) {
         LastCallFailCause failCause = new LastCallFailCause();
         failCause.causeCode = p.readInt();
@@ -3594,12 +3598,12 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return failCause;
     }
 
-    private Object
+    protected Object
     responseVoid(Parcel p) {
         return null;
     }
 
-    private Object
+    protected Object
     responseCallForward(Parcel p) {
         int numInfos;
         CallForwardInfo infos[];
@@ -3622,7 +3626,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return infos;
     }
 
-    private Object
+    protected Object
     responseSuppServiceNotification(Parcel p) {
         SuppServiceNotification notification = new SuppServiceNotification();
 
@@ -3635,7 +3639,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return notification;
     }
 
-    private Object
+    protected Object
     responseCdmaSms(Parcel p) {
         SmsMessage sms;
         sms = SmsMessage.newFromParcel(p);
@@ -3643,7 +3647,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return sms;
     }
 
-    private Object
+    protected Object
     responseString(Parcel p) {
         String response;
 
@@ -3652,7 +3656,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseStrings(Parcel p) {
         int num;
         String response[];
@@ -3662,7 +3666,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseRaw(Parcel p) {
         int num;
         byte response[];
@@ -3672,7 +3676,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseSMS(Parcel p) {
         int messageRef, errorCode;
         String ackPDU;
@@ -3687,7 +3691,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
     }
 
 
-    private Object
+    protected Object
     responseICC_IO(Parcel p) {
         int sw1, sw2;
         Message ret;
@@ -3705,7 +3709,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return new IccIoResult(sw1, sw2, s);
     }
 
-    private Object
+    protected Object
     responseICC_IOBase64(Parcel p) {
         int sw1, sw2;
         Message ret;
@@ -3724,7 +3728,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
                 ? android.util.Base64.decode(s, android.util.Base64.DEFAULT) : (byte[]) null);
     }
 
-    private Object
+    protected Object
     responseIccCardStatus(Parcel p) {
         IccCardApplicationStatus appStatus;
 
@@ -3756,7 +3760,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return cardStatus;
     }
 
-    private Object
+    protected Object
     responseSimRefresh(Parcel p) {
         IccRefreshResponse response = new IccRefreshResponse();
 
@@ -3766,7 +3770,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseCallList(Parcel p) {
         int num;
         int voiceSettings;
@@ -3844,7 +3848,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private DataCallResponse getDataCallResponse(Parcel p, int version) {
+    protected DataCallResponse getDataCallResponse(Parcel p, int version) {
         DataCallResponse dataCall = new DataCallResponse();
 
         dataCall.version = version;
@@ -3897,7 +3901,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return dataCall;
     }
 
-    private Object
+    protected Object
     responseDataCallList(Parcel p) {
         ArrayList<DataCallResponse> response;
 
@@ -3915,7 +3919,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseSetupDataCall(Parcel p) {
         int ver = p.readInt();
         int num = p.readInt();
@@ -3969,7 +3973,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return dataCall;
     }
 
-    private Object
+    protected Object
     responseOperatorInfos(Parcel p) {
         String strings[] = (String [])responseStrings(p);
         ArrayList<OperatorInfo> ret;
@@ -3994,7 +3998,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return ret;
     }
 
-    private Object
+    protected Object
     responseCellList(Parcel p) {
        int num, rssi;
        String location;
@@ -4022,7 +4026,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
        return response;
     }
 
-    private Object responseGetPreferredNetworkType(Parcel p) {
+    protected Object responseGetPreferredNetworkType(Parcel p) {
        int [] response = (int[]) responseInts(p);
 
        if (response.length >= 1) {
@@ -4034,7 +4038,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
        return response;
     }
 
-    private Object responseGmsBroadcastConfig(Parcel p) {
+    protected Object responseGmsBroadcastConfig(Parcel p) {
         int num;
         ArrayList<SmsBroadcastConfigInfo> response;
         SmsBroadcastConfigInfo info;
@@ -4056,7 +4060,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseCdmaBroadcastConfig(Parcel p) {
         int numServiceCategories;
         int response[];
@@ -4095,7 +4099,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseSignalStrength(Parcel p) {
         // Assume this is gsm, but doesn't matter as ServiceStateTracker
         // sets the proper value.
@@ -4103,7 +4107,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return signalStrength;
     }
 
-    private ArrayList<CdmaInformationRecords>
+    protected ArrayList<CdmaInformationRecords>
     responseCdmaInformationRecord(Parcel p) {
         int numberOfInfoRecs;
         ArrayList<CdmaInformationRecords> response;
@@ -4123,7 +4127,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private Object
+    protected Object
     responseCdmaCallWaiting(Parcel p) {
         CdmaCallWaitingNotification notification = new CdmaCallWaitingNotification();
 
@@ -4142,7 +4146,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return notification;
     }
 
-    private Object
+    protected Object
     responseCallRing(Parcel p){
         char response[] = new char[4];
 
@@ -4156,7 +4160,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-    private void
+    protected void
     notifyRegistrantsCdmaInfoRec(CdmaInformationRecords infoRec) {
         int response = RIL_UNSOL_CDMA_INFO_REC;
         if (infoRec.record instanceof CdmaInformationRecords.CdmaDisplayInfoRec) {
@@ -4204,7 +4208,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private ArrayList<CellInfo> responseCellInfoList(Parcel p) {
+    protected ArrayList<CellInfo> responseCellInfoList(Parcel p) {
         int numberOfInfoRecs;
         ArrayList<CellInfo> response;
 
@@ -4223,7 +4227,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return response;
     }
 
-   private Object
+   protected Object
    responseHardwareConfig(Parcel p) {
       int num;
       ArrayList<HardwareConfig> response;
@@ -4261,7 +4265,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
       return response;
    }
 
-    private Object
+    protected Object
     responseRadioCapability(Parcel p) {
         int version = p.readInt();
         int session = p.readInt();
@@ -4281,7 +4285,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return rc;
     }
 
-    private Object responseLceData(Parcel p) {
+    protected Object responseLceData(Parcel p) {
         final ArrayList<Integer> capacityResponse = new ArrayList<Integer>();
         final int capacityDownKbps = p.readInt();
         final int confidenceLevel = p.readByte();
@@ -4298,7 +4302,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return capacityResponse;
     }
 
-    private Object responseLceStatus(Parcel p) {
+    protected Object responseLceStatus(Parcel p) {
         final ArrayList<Integer> statusResponse = new ArrayList<Integer>();
         final int lceStatus = (int)p.readByte();
         final int actualInterval = p.readInt();
@@ -4311,7 +4315,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         return statusResponse;
     }
 
-    private Object responseActivityData(Parcel p) {
+    protected Object responseActivityData(Parcel p) {
         final int sleepModeTimeMs = p.readInt();
         final int idleModeTimeMs = p.readInt();
         int [] txModeTimeMs = new int[ModemActivityInfo.TX_POWER_LEVELS];
@@ -4582,29 +4586,29 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private void riljLog(String msg) {
+    protected void riljLog(String msg) {
         Rlog.d(RILJ_LOG_TAG, msg
                 + (mInstanceId != null ? (" [SUB" + mInstanceId + "]") : ""));
     }
 
-    private void riljLogv(String msg) {
+    protected void riljLogv(String msg) {
         Rlog.v(RILJ_LOG_TAG, msg
                 + (mInstanceId != null ? (" [SUB" + mInstanceId + "]") : ""));
     }
 
-    private void unsljLog(int response) {
+    protected void unsljLog(int response) {
         riljLog("[UNSL]< " + responseToString(response));
     }
 
-    private void unsljLogMore(int response, String more) {
+    protected void unsljLogMore(int response, String more) {
         riljLog("[UNSL]< " + responseToString(response) + " " + more);
     }
 
-    private void unsljLogRet(int response, Object ret) {
+    protected void unsljLogRet(int response, Object ret) {
         riljLog("[UNSL]< " + responseToString(response) + " " + retToString(response, ret));
     }
 
-    private void unsljLogvRet(int response, Object ret) {
+    protected void unsljLogvRet(int response, Object ret) {
         riljLogv("[UNSL]< " + responseToString(response) + " " + retToString(response, ret));
     }
 

--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -29,6 +29,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.hardware.display.DisplayManager;
 import android.net.ConnectivityManager;
 import android.net.LocalSocket;
@@ -90,6 +91,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -297,6 +299,7 @@ public final class RIL extends BaseCommands implements CommandsInterface {
     AtomicBoolean mTestingEmergencyCall = new AtomicBoolean(false);
 
     private Integer mInstanceId;
+    private List<String> mOldRilFeatures;
 
     private TelephonyEventLog mEventLog;
 
@@ -739,6 +742,9 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         mPhoneType = RILConstants.NO_PHONE;
         mInstanceId = instanceId;
 
+        final String oldRilFeatures = SystemProperties.get("ro.telephony.ril.config", "");
+        mOldRilFeatures = Arrays.asList(oldRilFeatures.split(","));
+
         mEventLog = new TelephonyEventLog(mInstanceId);
         PowerManager pm = (PowerManager)context.getSystemService(Context.POWER_SERVICE);
         mWakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, RILJ_LOG_TAG);
@@ -830,19 +836,17 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         send(rr);
     }
 
-    public void setUiccSubscription(int slotId, int appIndex, int subId,
-            int subStatus, Message result) {
+    public void setUiccSubscription(int appIndex, boolean activate, Message result) {
         //Note: This RIL request is also valid for SIM and RUIM (ICC card)
         RILRequest rr = RILRequest.obtain(RIL_REQUEST_SET_UICC_SUBSCRIPTION, result);
 
         if (RILJ_LOGD) riljLog(rr.serialString() + "> " + requestToString(rr.mRequest)
-                + " slot: " + slotId + " appIndex: " + appIndex
-                + " subId: " + subId + " subStatus: " + subStatus);
+                + " appIndex: " + appIndex + " activate: " + activate);
 
-        rr.mParcel.writeInt(slotId);
+        rr.mParcel.writeInt(mInstanceId);
         rr.mParcel.writeInt(appIndex);
-        rr.mParcel.writeInt(subId);
-        rr.mParcel.writeInt(subStatus);
+        rr.mParcel.writeInt(mInstanceId);
+        rr.mParcel.writeInt(activate ? 1 : 0);
 
         send(rr);
     }
@@ -1079,7 +1083,10 @@ public final class RIL extends BaseCommands implements CommandsInterface {
     getIMSIForApp(String aid, Message result) {
         RILRequest rr = RILRequest.obtain(RIL_REQUEST_GET_IMSI, result);
 
-        rr.mParcel.writeInt(1);
+        boolean writeAidOnly = needsOldRilFeature("writeaidonly");
+        if (!writeAidOnly) {
+            rr.mParcel.writeInt(1);
+        }
         rr.mParcel.writeString(aid);
 
         if (RILJ_LOGD) riljLog(rr.serialString() +
@@ -2424,6 +2431,14 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         switch(stateInt) {
             case 0: state = RadioState.RADIO_OFF; break;
             case 1: state = RadioState.RADIO_UNAVAILABLE; break;
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+            case 9:
             case 10: state = RadioState.RADIO_ON; break;
 
             default:
@@ -3440,6 +3455,9 @@ public final class RIL extends BaseCommands implements CommandsInterface {
 
                 // Initial conditions
                 setRadioPower(false, null);
+                if (needsOldRilFeature("setPrefNwTypeOnUnsolConnected")) {
+                    setPreferredNetworkType(mPreferredNetworkType, null);
+                }
                 setCdmaSubscriptionSource(mCdmaSubscription, null);
                 setCellInfoListRate(Integer.MAX_VALUE, null);
                 notifyRegistrantsRilConnectionChanged(((int[])ret)[0]);
@@ -3829,10 +3847,15 @@ public final class RIL extends BaseCommands implements CommandsInterface {
             dataCall.cid = p.readInt();
             dataCall.active = p.readInt();
             dataCall.type = p.readString();
+            if (version < 4) p.readString(); // APN not used
             String addresses = p.readString();
             if (!TextUtils.isEmpty(addresses)) {
                 dataCall.addresses = addresses.split(" ");
             }
+            // DataCallState needs an ifname. Since we don't have one,
+            // use the name from the ThrottleService resource. (default = rmnet0)
+            dataCall.ifname = Resources.getSystem().getString(
+                    com.android.internal.R.string.config_datause_iface);
         } else {
             dataCall.status = p.readInt();
             dataCall.suggestedRetryTime = p.readInt();
@@ -4946,6 +4969,16 @@ public final class RIL extends BaseCommands implements CommandsInterface {
      */
     @Override
     public void iccOpenLogicalChannel(String AID, Message response) {
+        if (mRilVersion < 10) {
+            if (response != null) {
+                CommandException ex = new CommandException(
+                        CommandException.Error.REQUEST_NOT_SUPPORTED);
+                AsyncResult.forMessage(response, null, ex);
+                response.sendToTarget();
+            }
+            return;
+        }
+
         RILRequest rr = RILRequest.obtain(RIL_REQUEST_SIM_OPEN_CHANNEL, response);
         rr.mParcel.writeString(AID);
 
@@ -4988,6 +5021,16 @@ public final class RIL extends BaseCommands implements CommandsInterface {
     @Override
     public void iccTransmitApduLogicalChannel(int channel, int cla, int instruction,
             int p1, int p2, int p3, String data, Message response) {
+        if (mRilVersion < 10) {
+            if (response != null) {
+                CommandException ex = new CommandException(
+                        CommandException.Error.REQUEST_NOT_SUPPORTED);
+                AsyncResult.forMessage(response, null, ex);
+                response.sendToTarget();
+            }
+            return;
+        }
+
         if (channel <= 0) {
             throw new RuntimeException(
                 "Invalid channel in iccTransmitApduLogicalChannel: " + channel);
@@ -5027,6 +5070,16 @@ public final class RIL extends BaseCommands implements CommandsInterface {
      */
     private void iccTransmitApduHelper(int rilCommand, int channel, int cla,
             int instruction, int p1, int p2, int p3, String data, Message response) {
+        if (mRilVersion < 10) {
+            if (response != null) {
+                CommandException ex = new CommandException(
+                        CommandException.Error.REQUEST_NOT_SUPPORTED);
+                AsyncResult.forMessage(response, null, ex);
+                response.sendToTarget();
+            }
+            return;
+        }
+
         RILRequest rr = RILRequest.obtain(rilCommand, response);
         rr.mParcel.writeInt(channel);
         rr.mParcel.writeInt(cla);
@@ -5207,5 +5260,9 @@ public final class RIL extends BaseCommands implements CommandsInterface {
             + " with " + adnRecordInfo.toString());
 
         send(rr);
+    }
+
+    public boolean needsOldRilFeature(String feature) {
+        return mOldRilFeatures.contains(feature);
     }
 }

--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -303,6 +303,11 @@ public final class RIL extends BaseCommands implements CommandsInterface {
 
     private TelephonyEventLog mEventLog;
 
+    // Number of per-network elements expected in QUERY_AVAILABLE_NETWORKS's response.
+    // 4 elements is default, but many RILs actually return 5, making it impossible to
+    // divide the response array without prior knowledge of the number of elements.
+    protected int mQANElements = SystemProperties.getInt("ro.ril.telephony.mqanelements", 4);
+
     //***** Events
 
     static final int EVENT_SEND                 = 1;
@@ -3969,15 +3974,15 @@ public final class RIL extends BaseCommands implements CommandsInterface {
         String strings[] = (String [])responseStrings(p);
         ArrayList<OperatorInfo> ret;
 
-        if (strings.length % 4 != 0) {
+        if (strings.length % mQANElements != 0) {
             throw new RuntimeException(
                 "RIL_REQUEST_QUERY_AVAILABLE_NETWORKS: invalid response. Got "
-                + strings.length + " strings, expected multible of 4");
+                + strings.length + " strings, expected multiple of " + mQANElements);
         }
 
-        ret = new ArrayList<OperatorInfo>(strings.length / 4);
+        ret = new ArrayList<OperatorInfo>(strings.length / mQANElements);
 
-        for (int i = 0 ; i < strings.length ; i += 4) {
+        for (int i = 0 ; i < strings.length ; i += mQANElements) {
             ret.add (
                 new OperatorInfo(
                     strings[i+0],

--- a/src/java/com/android/internal/telephony/SmsApplication.java
+++ b/src/java/com/android/internal/telephony/SmsApplication.java
@@ -40,6 +40,7 @@ import android.provider.Telephony.Sms.Intents;
 import android.telephony.Rlog;
 import android.telephony.SmsManager;
 import android.telephony.TelephonyManager;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.android.internal.content.PackageMonitor;
@@ -61,6 +62,7 @@ public final class SmsApplication {
     private static final String BLUETOOTH_PACKAGE_NAME = "com.android.bluetooth";
     private static final String MMS_SERVICE_PACKAGE_NAME = "com.android.mms.service";
     private static final String TELEPHONY_PROVIDER_PACKAGE_NAME = "com.android.providers.telephony";
+    private static final String DEFAULT_SYSTEM_MMS_PACKAGE_NAME = "com.android.messaging";
 
     private static final String SCHEME_SMS = "sms";
     private static final String SCHEME_SMSTO = "smsto";
@@ -896,6 +898,16 @@ public final class SmsApplication {
             return true;
         }
         return false;
+    }
+
+    /**
+     * @hide
+     */
+    public static boolean canSmsAppHandleAlwaysAsk(Context context) {
+        final ComponentName defaultMmsApplication = SmsApplication.getDefaultMmsApplication(context,
+                false);
+        return TextUtils.equals(DEFAULT_SYSTEM_MMS_PACKAGE_NAME,
+                defaultMmsApplication.getPackageName());
     }
 
     private static String getDefaultSmsApplicationPackageName(Context context) {

--- a/src/java/com/android/internal/telephony/SubscriptionInfoUpdater.java
+++ b/src/java/com/android/internal/telephony/SubscriptionInfoUpdater.java
@@ -52,6 +52,7 @@ import com.android.internal.telephony.uicc.IccUtils;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -74,6 +75,9 @@ public class SubscriptionInfoUpdater extends Handler {
     private static final int EVENT_SIM_LOCKED = 5;
     private static final int EVENT_SIM_IO_ERROR = 6;
     private static final int EVENT_SIM_UNKNOWN = 7;
+    private static final int EVENT_UPDATE_INSERTED_SIM_COUNT = 8;
+
+    private static final int DELAY_MILLIS = 500;
 
     private static final String ICCID_STRING_FOR_NO_SIM = "";
     /**
@@ -101,6 +105,8 @@ public class SubscriptionInfoUpdater extends Handler {
 
     // Key used to read/write the current IMSI. Updated on SIM_STATE_CHANGED - LOADED.
     public static final String CURR_SUBID = "curr_subid";
+    // Key used to determine if the number of sims in the device has changed
+    private static final String PREF_LAST_SEEN_SIM_COUNT = "previous_update_sim_count";
 
     private static Phone[] mPhone;
     private static Context mContext = null;
@@ -114,6 +120,9 @@ public class SubscriptionInfoUpdater extends Handler {
     // The current foreground user ID.
     private int mCurrentlyActiveUserId;
     private CarrierServiceBindHelper mCarrierServiceBindHelper;
+    private boolean mIsShutdown;
+    private int mCurrentSimCount = 0;
+    private BitSet mLockedSims = new BitSet(PROJECT_SIM_NUM);
 
     public SubscriptionInfoUpdater(Context context, Phone[] phone, CommandsInterface[] ci) {
         logd("Constructor invoked");
@@ -123,10 +132,12 @@ public class SubscriptionInfoUpdater extends Handler {
         mSubscriptionManager = SubscriptionManager.from(mContext);
         mPackageManager = IPackageManager.Stub.asInterface(ServiceManager.getService("package"));
         mUserManager = (UserManager) mContext.getSystemService(Context.USER_SERVICE);
+        mIsShutdown = false;
 
         IntentFilter intentFilter = new IntentFilter(TelephonyIntents.ACTION_SIM_STATE_CHANGED);
         intentFilter.addAction(IccCardProxy.ACTION_INTERNAL_SIM_STATE_CHANGED);
         intentFilter.addAction(Intent.ACTION_USER_UNLOCKED);
+        intentFilter.addAction(Intent.ACTION_SHUTDOWN);
         mContext.registerReceiver(sReceiver, intentFilter);
 
         mCarrierServiceBindHelper = new CarrierServiceBindHelper(mContext);
@@ -199,6 +210,11 @@ public class SubscriptionInfoUpdater extends Handler {
                 return;
             }
 
+            if (action.equals(Intent.ACTION_SHUTDOWN)) {
+                mIsShutdown = true;
+                return;
+            }
+
             if (!action.equals(TelephonyIntents.ACTION_SIM_STATE_CHANGED) &&
                     !action.equals(IccCardProxy.ACTION_INTERNAL_SIM_STATE_CHANGED)) {
                 return;
@@ -235,6 +251,16 @@ public class SubscriptionInfoUpdater extends Handler {
                     logd("Ignoring simStatus: " + simStatus);
                 }
             }
+
+            if (IccCardConstants.INTENT_VALUE_ICC_LOCKED.equals(simStatus)) {
+                mLockedSims.set(slotId);
+                update(slotId);
+            } else if (IccCardConstants.INTENT_VALUE_ICC_READY.equals(simStatus)
+                    || IccCardConstants.INTENT_VALUE_ICC_LOADED.equals(simStatus)) {
+                mLockedSims.clear(slotId);
+                update(slotId);
+            }
+
             logd("[Receiver]-");
         }
     };
@@ -294,9 +320,7 @@ public class SubscriptionInfoUpdater extends Handler {
                     logd("Query IccId fail: " + ar.exception);
                 }
                 logd("sIccId[" + slotId + "] = " + mIccId[slotId]);
-                if (isAllIccIdQueryDone()) {
-                    updateSubscriptionInfoByIccId();
-                }
+                update(slotId);
                 broadcastSimStateChanged(slotId, IccCardConstants.INTENT_VALUE_ICC_LOCKED,
                                          uObj.reason);
                 if (!ICCID_STRING_FOR_NO_SIM.equals(mIccId[slotId])) {
@@ -339,6 +363,14 @@ public class SubscriptionInfoUpdater extends Handler {
                 handleSimAbsentOrError(msg.arg1, IccCardConstants.INTENT_VALUE_ICC_CARD_IO_ERROR);
                 break;
 
+            case EVENT_UPDATE_INSERTED_SIM_COUNT:
+                logd("EVENT_UPDATE_INSERTED_SIM_COUNT: locked sims: " + mLockedSims.cardinality());
+                if (isAllIccIdQueryDone() && !hasMessages(EVENT_UPDATE_INSERTED_SIM_COUNT)) {
+                    updateSubscriptionInfoByIccId();
+                    logd("update inserted sim count, current sim count: " + mCurrentSimCount);
+                }
+                break;
+
             default:
                 logd("Unknown msg:" + msg.what);
         }
@@ -360,7 +392,6 @@ public class SubscriptionInfoUpdater extends Handler {
             mIccId[slotId] = null;
         }
 
-
         IccFileHandler fileHandler = mPhone[slotId].getIccCard() == null ? null :
                 mPhone[slotId].getIccCard().getIccFileHandler();
 
@@ -378,6 +409,14 @@ public class SubscriptionInfoUpdater extends Handler {
             }
         } else {
             logd("sFh[" + slotId + "] is null, ignore");
+        }
+        update(slotId);
+    }
+
+    private void update(int slotId) {
+        sendMessageDelayed(obtainMessage(EVENT_UPDATE_INSERTED_SIM_COUNT, slotId), DELAY_MILLIS);
+        if (isAllIccIdQueryDone()) {
+            updateSubscriptionInfoByIccId();
         }
     }
 
@@ -397,10 +436,7 @@ public class SubscriptionInfoUpdater extends Handler {
             return;
         }
         mIccId[slotId] = records.getIccId();
-
-        if (isAllIccIdQueryDone()) {
-            updateSubscriptionInfoByIccId();
-        }
+        update(slotId);
 
         int subId = SubscriptionManager.DEFAULT_SUBSCRIPTION_ID;
         int[] subIds = SubscriptionController.getInstance().getSubId(slotId);
@@ -520,9 +556,7 @@ public class SubscriptionInfoUpdater extends Handler {
             logd("SIM" + (slotId + 1) + " hot plug out or error");
         }
         mIccId[slotId] = ICCID_STRING_FOR_NO_SIM;
-        if (isAllIccIdQueryDone()) {
-            updateSubscriptionInfoByIccId();
-        }
+        update(slotId);
         updateCarrierServices(slotId, simState);
     }
 
@@ -533,7 +567,11 @@ public class SubscriptionInfoUpdater extends Handler {
     synchronized protected void updateSubscriptionInfoByIccId() {
         logd("updateSubscriptionInfoByIccId:+ Start");
 
-        mSubscriptionManager.clearSubscriptionInfo();
+        // only update external state if we have no pending updates pending
+        boolean update = !hasMessages(EVENT_UPDATE_INSERTED_SIM_COUNT);
+        if (update) {
+            mSubscriptionManager.clearSubscriptionInfo();
+        }
 
         for (int i = 0; i < PROJECT_SIM_NUM; i++) {
             mInsertSimState[i] = SIM_NOT_CHANGE;
@@ -547,6 +585,7 @@ public class SubscriptionInfoUpdater extends Handler {
             }
         }
         logd("insertedSimCount = " + insertedSimCount);
+        mCurrentSimCount = insertedSimCount;
 
         int index = 0;
         for (int i = 0; i < PROJECT_SIM_NUM; i++) {
@@ -607,13 +646,13 @@ public class SubscriptionInfoUpdater extends Handler {
             if (mInsertSimState[i] == SIM_NOT_INSERT) {
                 logd("updateSubscriptionInfoByIccId: No SIM inserted in slot " + i + " this time");
             } else {
-                if (mInsertSimState[i] > 0) {
+                if (mInsertSimState[i] > 0 && update) {
                     //some special SIMs may have the same IccIds, add suffix to distinguish them
                     //FIXME: addSubInfoRecord can return an error.
                     mSubscriptionManager.addSubscriptionInfoRecord(mIccId[i]
                             + Integer.toString(mInsertSimState[i]), i);
                     logd("SUB" + (i + 1) + " has invalid IccId");
-                } else /*if (sInsertSimState[i] != SIM_NOT_INSERT)*/ {
+                } else if (update)/*if (sInsertSimState[i] != SIM_NOT_INSERT)*/ {
                     mSubscriptionManager.addSubscriptionInfoRecord(mIccId[i], i);
                 }
                 if (isNewSim(mIccId[i], oldIccId)) {
@@ -664,12 +703,66 @@ public class SubscriptionInfoUpdater extends Handler {
             }
         }
 
-        // Ensure the modems are mapped correctly
-        mSubscriptionManager.setDefaultDataSubId(
-                mSubscriptionManager.getDefaultDataSubscriptionId());
+        if (update && !mIsShutdown && mLockedSims.cardinality() == 0) {
+            final int previousUpdateSimCount = previousUpdateSimCount();
+            if (previousUpdateSimCount != insertedSimCount) {
+                logd("number of sims changed, resetting sms prompt, old sim count: "
+                        + previousUpdateSimCount);
+                if (insertedSimCount == 1 && PROJECT_SIM_NUM > 1) {
+                    // 1 sim, msim device: clear stale defaults (doesn't clear inactive subs)
+                    mSubscriptionManager.clearDefaultsForInactiveSubIds();
 
-        SubscriptionController.getInstance().notifySubscriptionInfoChanged();
+                    // then disable sms prompt (sms app will default to inserted sim)
+                    PhoneFactory.setSMSPromptEnabled(false); // can't prompt for 1 sim
+
+                    // finally, disable data if this single sim isn't our our selected data sim previously
+                    int realStoredDataSub = Settings.Global.getInt(mContext.getContentResolver(),
+                            Settings.Global.MULTI_SIM_DATA_CALL_SUBSCRIPTION,
+                            SubscriptionManager.INVALID_SUBSCRIPTION_ID);
+
+                    if (realStoredDataSub != SubscriptionManager.INVALID_SUBSCRIPTION_ID &&
+                            realStoredDataSub != SubscriptionManager.getDefaultDataSubscriptionId()) {
+                        logd("switching data off; real stored sub: " + realStoredDataSub
+                                + ", and we think the default sub id is now: "
+                                + SubscriptionManager.getDefaultDataSubscriptionId());
+                        PhoneFactory.getDefaultPhone().setDataEnabled(false);
+                    }
+                } else if (insertedSimCount > 1) {
+                    // we now have multiple sims, maybe enable the SMS prompt if no valid
+                    // sub is ready to handle SMS
+                    PhoneFactory.setSMSPromptEnabled(!SubscriptionManager.isValidSubscriptionId(
+                            SubscriptionManager.getDefaultSmsSubscriptionId()));
+                }
+                setPreviousUpdateSimCount(insertedSimCount);
+            }
+            // Ensure the modems are mapped correctly
+            // will not override MSIM settings with 1 sim in the device.
+            mSubscriptionManager.setDefaultDataSubId(SubscriptionManager.getDefaultDataSubscriptionId());
+            SubscriptionController.getInstance().notifySubscriptionInfoChanged();
+        } else if (update && !mIsShutdown) {
+            // we have locked sims, need to update so we can unlock them
+            SubscriptionController.getInstance().notifySubscriptionInfoChanged();
+        }
         logd("updateSubscriptionInfoByIccId:- SsubscriptionInfo update complete");
+    }
+
+    private int previousUpdateSimCount() {
+        return PreferenceManager.getDefaultSharedPreferences(mContext)
+                .getInt(PREF_LAST_SEEN_SIM_COUNT, 0);
+    }
+
+    private void setPreviousUpdateSimCount(int simCount) {
+        PreferenceManager.getDefaultSharedPreferences(mContext)
+                .edit()
+                .putInt(PREF_LAST_SEEN_SIM_COUNT, simCount)
+                .apply();
+    }
+
+    protected int getInsertedSimCount() {
+        if (!isAllIccIdQueryDone()) {
+            return 0;
+        }
+        return mCurrentSimCount;
     }
 
     private boolean isNewSim(String iccId, String[] oldIccId) {

--- a/src/java/com/android/internal/telephony/dataconnection/DataCallResponse.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DataCallResponse.java
@@ -143,7 +143,7 @@ public class DataCallResponse {
                         String [] ap = addr.split("/");
                         if (ap.length == 2) {
                             addr = ap[0];
-                            addrPrefixLen = Integer.parseInt(ap[1]);
+                            addrPrefixLen = Integer.parseInt(ap[1].replaceAll("[\\D]",""));
                         } else {
                             addrPrefixLen = 0;
                         }

--- a/src/java/com/android/internal/telephony/test/SimulatedCommandsVerifier.java
+++ b/src/java/com/android/internal/telephony/test/SimulatedCommandsVerifier.java
@@ -1292,8 +1292,7 @@ public class SimulatedCommandsVerifier implements CommandsInterface {
     }
 
     @Override
-    public void setUiccSubscription(int slotId, int appIndex, int subId, int subStatus,
-                                    Message result) {
+    public void setUiccSubscription(int appIndex, boolean activate, Message result) {
 
     }
 

--- a/src/java/com/android/internal/telephony/uicc/UiccCard.java
+++ b/src/java/com/android/internal/telephony/uicc/UiccCard.java
@@ -46,6 +46,7 @@ import android.view.WindowManager;
 
 import com.android.internal.telephony.CommandsInterface;
 import com.android.internal.telephony.CommandsInterface.RadioState;
+import com.android.internal.telephony.RIL;
 import com.android.internal.telephony.uicc.IccCardApplicationStatus.AppType;
 import com.android.internal.telephony.uicc.IccCardStatus.CardState;
 import com.android.internal.telephony.uicc.IccCardStatus.PinState;
@@ -85,6 +86,7 @@ public class UiccCard {
     private CatService mCatService;
     private RadioState mLastRadioState =  RadioState.RADIO_UNAVAILABLE;
     private UiccCarrierPrivilegeRules mCarrierPrivilegeRules;
+    private boolean mDefaultAppsActivated;
 
     private RegistrantList mAbsentRegistrants = new RegistrantList();
     private RegistrantList mCarrierPrivilegeRegistrants = new RegistrantList();
@@ -192,8 +194,28 @@ public class UiccCard {
                     mHandler.sendMessage(mHandler.obtainMessage(EVENT_CARD_ADDED, null));
                 }
             }
+            if (needsSimActivation()) {
+                if (mCardState == CardState.CARDSTATE_PRESENT) {
+                    if (!mDefaultAppsActivated) {
+                        activateDefaultApps();
+                        mDefaultAppsActivated = true;
+                    }
+                } else {
+                    // SIM removed, reset activation flag to make sure
+                    // to re-run the activation at the next insertion
+                    mDefaultAppsActivated = false;
+                }
+            }
+
             mLastRadioState = radioState;
         }
+    }
+
+    private boolean needsSimActivation() {
+        if (mCi instanceof RIL) {
+            return ((RIL) mCi).needsOldRilFeature("simactivation");
+        }
+        return false;
     }
 
     protected void createAndUpdateCatService() {
@@ -255,6 +277,34 @@ public class UiccCard {
 
         // Seems to be valid
         return index;
+    }
+
+    private void activateDefaultApps() {
+        int gsmIndex = mGsmUmtsSubscriptionAppIndex;
+        int cdmaIndex = mCdmaSubscriptionAppIndex;
+
+        if (gsmIndex < 0 || cdmaIndex < 0) {
+            for (int i = 0; i < mUiccApplications.length; i++) {
+                if (mUiccApplications[i] == null) {
+                    continue;
+                }
+
+                AppType appType = mUiccApplications[i].getType();
+                if (gsmIndex < 0
+                        && (appType == AppType.APPTYPE_USIM || appType == AppType.APPTYPE_SIM)) {
+                    gsmIndex = i;
+                } else if (cdmaIndex < 0 &&
+                        (appType == AppType.APPTYPE_CSIM || appType == AppType.APPTYPE_RUIM)) {
+                    cdmaIndex = i;
+                }
+            }
+        }
+        if (gsmIndex >= 0) {
+            mCi.setUiccSubscription(gsmIndex, true, null);
+        }
+        if (cdmaIndex >= 0) {
+            mCi.setUiccSubscription(cdmaIndex, true, null);
+        }
     }
 
     /**


### PR DESCRIPTION
- TelephonyComponentFactory.makePhone expects a type of
  PhoneConstants.PHONE_TYPE_GSM or PhoneConstants.PHONE_TYPE_CDMA
  but we're sending in PhoneConstants.PHONE_TYPE_CDMA_LTE which
  is going to end up leaving us with a null Phone object

Change-Id: I76ae6149199e7fa625eb9b85b39d3985e04aecf4
